### PR TITLE
Add missing release notes from 6 failed workflow runs

### DIFF
--- a/content/ansattporten/prod-releases/ansattporten-altinn-gateway-e54d31d7e3c66c20d3d81dddda2f4d347318cb5a.md
+++ b/content/ansattporten/prod-releases/ansattporten-altinn-gateway-e54d31d7e3c66c20d3d81dddda2f4d347318cb5a.md
@@ -1,0 +1,5 @@
+---
+title: ansattporten
+date: 2025-07-16T06:27:35Z
+---
+- Library upgrades

--- a/content/ansattporten/prod-releases/ansattporten-c2id-server-400716fe2de09dedc52ec5135ff5209805ace15b.md
+++ b/content/ansattporten/prod-releases/ansattporten-c2id-server-400716fe2de09dedc52ec5135ff5209805ace15b.md
@@ -1,0 +1,8 @@
+---
+title: ansattporten
+date: 2026-04-28T08:16:46Z
+environment: 
+---
+- ID-6361: Downgrade c2id-server to version 19.9 and c2id-server-min to version 19.10 adjust log4j version to 2.25.3 (#1046)
+- ID-6341: Upgrade c2id-server to version 19.11 (#1044)
+- ID-6320: Upgrade c2id-server to version 19.10 (#1040)

--- a/content/ansattporten/prod-releases/ansattporten-claimsprovider-altinn-orgvelger-dfdb84aca614fb3bc94f21fdaf0e8983185b83bf.md
+++ b/content/ansattporten/prod-releases/ansattporten-claimsprovider-altinn-orgvelger-dfdb84aca614fb3bc94f21fdaf0e8983185b83bf.md
@@ -1,0 +1,6 @@
+---
+title: ansattporten
+date: 2026-04-28T10:18:12Z
+environment: 
+---
+- ID-5977: Velg alle på orgvelger filtrerer nå bort organisasjoner bruker ikke kan representere (#531)

--- a/content/ansattporten/prod-releases/ansattporten-freg-gateway-316f39e8ec306e6253a79d2471fa113c67972a7f.md
+++ b/content/ansattporten/prod-releases/ansattporten-freg-gateway-316f39e8ec306e6253a79d2471fa113c67972a7f.md
@@ -1,0 +1,13 @@
+---
+title: ansattporten
+date: 2026-03-16T08:50:35Z
+---
+- MIN-2960 Rettet versjon av access-starter (#544)
+- KRR-1176 Endret server.port (#542)
+- KRR-1175 Endret key-alias (#541)
+- KRR-1175 Første forslag til application-efm-.yml-filer (#540)
+- PF-2275 fix: remove default value and specify for all (#539)
+- PF-2275 Variable for deployment-environment (#538)
+- MIN-2690 Oppdatert FregClientConfig og noen dependencies (#535)
+- MIN-2960 Oppdatert til Spring boot 4, Feign - Http Service Clients (#525)
+- MIN-2876: Legg til catalog-info.yaml for FREG-gateway i Backstage (#523)

--- a/content/ansattporten/prod-releases/ansattporten-login-0c95fa31cc2052a24b1806dd4c300f97315b0143.md
+++ b/content/ansattporten/prod-releases/ansattporten-login-0c95fa31cc2052a24b1806dd4c300f97315b0143.md
@@ -1,0 +1,7 @@
+---
+title: ansattporten
+date: 2026-04-08T07:31:30Z
+---
+- ID-6284: Add organization_name attribute to audit logs (#1412)
+- ID-6073: Use loginDisplayTextfor selector (#1411)
+- ID-6227: Filtrere claimsprovidere på acr (#1410)

--- a/content/ansattporten/prod-releases/ansattporten-minid-integration-813a6a408a008b5d972b11375e47d8791738aabd.md
+++ b/content/ansattporten/prod-releases/ansattporten-minid-integration-813a6a408a008b5d972b11375e47d8791738aabd.md
@@ -1,0 +1,5 @@
+---
+title: ansattporten
+date: 2026-02-18T13:46:19Z
+---
+- ID-6022: Oppgradere til spring boot 4 (#807)

--- a/content/ansattporten/prod-releases/ansattporten-scope-api-08610ecd625d0315efcea2c3313fdb267a60b004.md
+++ b/content/ansattporten/prod-releases/ansattporten-scope-api-08610ecd625d0315efcea2c3313fdb267a60b004.md
@@ -1,0 +1,6 @@
+---
+title: ansattporten
+date: 2026-04-28T08:32:06Z
+environment: 
+---
+- Library upgrades

--- a/content/eformidling/prod-releases/efm-move-admin-9ef09de36999c2d94f62a4cffe50266e0b0731f8.md
+++ b/content/eformidling/prod-releases/efm-move-admin-9ef09de36999c2d94f62a4cffe50266e0b0731f8.md
@@ -1,0 +1,5 @@
+---
+title: eformidling
+date: 2025-11-18T11:26:27Z
+---
+- Library upgrades

--- a/content/eidas/prod-releases/eidas-freg-gateway-5b13f1dca79ad7db3e2caad7ebece43036ee3370.md
+++ b/content/eidas/prod-releases/eidas-freg-gateway-5b13f1dca79ad7db3e2caad7ebece43036ee3370.md
@@ -1,0 +1,6 @@
+---
+title: eidas
+date: 2025-04-28T10:14:09Z
+---
+- Library upgrades
+- KRR-898 dockerfil (#368)

--- a/content/idporten/prod-releases/idporten-bankid-integration-813a6a408a008b5d972b11375e47d8791738aabd.md
+++ b/content/idporten/prod-releases/idporten-bankid-integration-813a6a408a008b5d972b11375e47d8791738aabd.md
@@ -1,0 +1,5 @@
+---
+title: idporten
+date: 2026-02-18T13:57:51Z
+---
+- ID-6022: Oppgradere til spring boot 4 (#807)

--- a/content/idporten/prod-releases/idporten-buypass-integration-0d6ec4f7c126d7be399899b613d3f60283508080.md
+++ b/content/idporten/prod-releases/idporten-buypass-integration-0d6ec4f7c126d7be399899b613d3f60283508080.md
@@ -1,0 +1,5 @@
+---
+title: idporten
+date: 2026-01-06T13:00:07Z
+---
+- ID-5820: Send med profile scope videre dersom satt (#786)

--- a/content/idporten/prod-releases/idporten-c2id-server-400716fe2de09dedc52ec5135ff5209805ace15b.md
+++ b/content/idporten/prod-releases/idporten-c2id-server-400716fe2de09dedc52ec5135ff5209805ace15b.md
@@ -1,0 +1,8 @@
+---
+title: idporten
+date: 2026-04-28T08:17:24Z
+environment: 
+---
+- ID-6361: Downgrade c2id-server to version 19.9 and c2id-server-min to version 19.10 adjust log4j version to 2.25.3 (#1046)
+- ID-6341: Upgrade c2id-server to version 19.11 (#1044)
+- ID-6320: Upgrade c2id-server to version 19.10 (#1040)

--- a/content/idporten/prod-releases/idporten-freg-gateway-9fd747162f9fba68170b1a5edca2e5020deca1ee.md
+++ b/content/idporten/prod-releases/idporten-freg-gateway-9fd747162f9fba68170b1a5edca2e5020deca1ee.md
@@ -1,0 +1,16 @@
+---
+title: idporten
+date: 2026-04-15T07:28:32Z
+---
+- Library upgrades
+- KRR-1175 Lagt til url i application-efm-prod.yml (#549)
+- KRR-1175 Rettet application-efm-prod.yml (#545)
+- MIN-2960 Rettet versjon av access-starter (#544)
+- KRR-1176 Endret server.port (#542)
+- KRR-1175 Endret key-alias (#541)
+- KRR-1175 Første forslag til application-efm-.yml-filer (#540)
+- PF-2275 fix: remove default value and specify for all (#539)
+- PF-2275 Variable for deployment-environment (#538)
+- MIN-2690 Oppdatert FregClientConfig og noen dependencies (#535)
+- MIN-2960 Oppdatert til Spring boot 4, Feign - Http Service Clients (#525)
+- MIN-2876: Legg til catalog-info.yaml for FREG-gateway i Backstage (#523)

--- a/content/idporten/prod-releases/idporten-fullmakt-demo-client-9ad4bea9887311590c5c747f10d270cc83a0074a.md
+++ b/content/idporten/prod-releases/idporten-fullmakt-demo-client-9ad4bea9887311590c5c747f10d270cc83a0074a.md
@@ -1,0 +1,5 @@
+---
+title: idporten
+date: 2025-11-07T07:48:31Z
+---
+- Library upgrades

--- a/content/idporten/prod-releases/idporten-minid-integration-813a6a408a008b5d972b11375e47d8791738aabd.md
+++ b/content/idporten/prod-releases/idporten-minid-integration-813a6a408a008b5d972b11375e47d8791738aabd.md
@@ -1,0 +1,5 @@
+---
+title: idporten
+date: 2026-02-18T13:56:51Z
+---
+- ID-6022: Oppgradere til spring boot 4 (#807)

--- a/content/idporten/prod-releases/idporten-scope-api-08610ecd625d0315efcea2c3313fdb267a60b004.md
+++ b/content/idporten/prod-releases/idporten-scope-api-08610ecd625d0315efcea2c3313fdb267a60b004.md
@@ -1,0 +1,6 @@
+---
+title: idporten
+date: 2026-04-28T10:18:31Z
+environment: 
+---
+- Library upgrades

--- a/content/idporten/prod-releases/idporten-static-resources-53566089ca87c0a27a8ccc62af5b1d440d7274b6.md
+++ b/content/idporten/prod-releases/idporten-static-resources-53566089ca87c0a27a8ccc62af5b1d440d7274b6.md
@@ -1,0 +1,6 @@
+---
+title: idporten
+date: 2026-01-22T14:00:45Z
+---
+- ID-5514: Snevre inn CORS (#21)
+- Library upgrades

--- a/content/krr/prod-releases/krr-reservasjon-e73edea86a096fa0eede9d89322e090913830fa6.md
+++ b/content/krr/prod-releases/krr-reservasjon-e73edea86a096fa0eede9d89322e090913830fa6.md
@@ -1,0 +1,5 @@
+---
+title: krr
+date: 2025-03-24T17:32:07Z
+---
+- Library upgrades

--- a/content/maskinporten/prod-releases/maskinporten-scope-api-d4c4ff3ac9567127615ea29bfabeb3a428370f50.md
+++ b/content/maskinporten/prod-releases/maskinporten-scope-api-d4c4ff3ac9567127615ea29bfabeb3a428370f50.md
@@ -1,0 +1,5 @@
+---
+title: maskinporten
+date: 2024-12-18T11:59:53Z
+---
+- Library upgrades

--- a/content/skyporten/prod-releases/skyporten-scope-api-08610ecd625d0315efcea2c3313fdb267a60b004.md
+++ b/content/skyporten/prod-releases/skyporten-scope-api-08610ecd625d0315efcea2c3313fdb267a60b004.md
@@ -1,0 +1,6 @@
+---
+title: skyporten
+date: 2026-04-27T12:19:43Z
+environment: 
+---
+- Library upgrades

--- a/content/skyporten/prod-releases/skyporten-scope-api-4e016d865d46c25a56ec91abd85d7e78d45fd6c1.md
+++ b/content/skyporten/prod-releases/skyporten-scope-api-4e016d865d46c25a56ec91abd85d7e78d45fd6c1.md
@@ -1,0 +1,5 @@
+---
+title: skyporten
+date: 2025-02-03T07:55:54Z
+---
+- MP-682: delegation slurper (#324)

--- a/content/skyporten/prod-releases/skyporten-scope-api-5e94a67e8a85d244a8430dafea15d9b2e61b7117.md
+++ b/content/skyporten/prod-releases/skyporten-scope-api-5e94a67e8a85d244a8430dafea15d9b2e61b7117.md
@@ -1,0 +1,5 @@
+---
+title: skyporten
+date: 2026-03-27T14:19:46Z
+---
+- Library upgrades


### PR DESCRIPTION
Bug i workflow for update-release-notes. Re run av jobber feiler da den ikke får med seg bugfix i main

---

Manually recovering release notes from 6 failed `update-release-notes-2` runs:

| Application | Product | Date |
|---|---|---|
| ansattporten-claimsprovider-altinn-orgvelger | ansattporten | 2026-04-28 |
| idporten-scope-api | idporten | 2026-04-28 |
| ansattporten-scope-api | ansattporten | 2026-04-28 |
| ansattporten-c2id-server | ansattporten | 2026-04-28 |
| idporten-c2id-server | idporten | 2026-04-28 |
| skyporten-scope-api | skyporten | 2026-04-27 |

Failed runs:
- https://github.com/digdir/release.digdir.no/actions/runs/25047418274
- https://github.com/digdir/release.digdir.no/actions/runs/25047371692
- https://github.com/digdir/release.digdir.no/actions/runs/25042662864
- https://github.com/digdir/release.digdir.no/actions/runs/25042062718
- https://github.com/digdir/release.digdir.no/actions/runs/25042004115
- https://github.com/digdir/release.digdir.no/actions/runs/24994747381